### PR TITLE
Navigation Componentによる画面遷移の実装

### DIFF
--- a/MonoTodo/app/src/main/java/com/example/monotodo/MainActivity.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/MainActivity.kt
@@ -7,10 +7,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import com.example.monotodo.ui.theme.MonoTodoTheme
 
 class MainActivity : ComponentActivity() {
@@ -26,21 +23,5 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    MonoTodoTheme {
-        Greeting("Android")
     }
 }

--- a/MonoTodo/app/src/main/java/com/example/monotodo/MonoTodoApp.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/MonoTodoApp.kt
@@ -14,14 +14,17 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.example.monotodo.ui.home.HomeScreen
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.example.monotodo.ui.navigation.MonoTodoNavHost
 
 @Composable
 fun MonoTodoApp(
+    navController: NavHostController = rememberNavController(),
     modifier: Modifier = Modifier
 ) {
-    HomeScreen(
-        navigateToTaskEntry = {},
+    MonoTodoNavHost(
+        navController = navController,
         modifier = modifier
     )
 }

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeScreen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeScreen.kt
@@ -35,13 +35,20 @@ import androidx.compose.ui.unit.dp
 import com.example.monotodo.MonoTodoTopAppBar
 import com.example.monotodo.R
 import com.example.monotodo.data.Task
+import com.example.monotodo.ui.navigation.NavigationDestination
 import com.example.monotodo.ui.theme.MonoTodoTheme
+
+object HomeDestination : NavigationDestination {
+    override val route = "home"
+    override val titleRes = R.string.app_name
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
     modifier: Modifier = Modifier,
-    navigateToTaskEntry: () -> Unit
+    navigateToTaskEntry: () -> Unit,
+    navigateToTaskCompleted: () -> Unit
 ) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
@@ -49,9 +56,10 @@ fun HomeScreen(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             MonoTodoTopAppBar(
-                title = stringResource(R.string.app_name),
+                title = stringResource(HomeDestination.titleRes),
                 canNavigateBack = false,
-                scrollBehavior = scrollBehavior
+                scrollBehavior = scrollBehavior,
+                navigateToTaskCompleted = navigateToTaskCompleted
             )
         },
         floatingActionButton = {

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/navigation/MonoTodoNavGraph.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/navigation/MonoTodoNavGraph.kt
@@ -1,0 +1,45 @@
+package com.example.monotodo.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import com.example.monotodo.ui.home.HomeDestination
+import com.example.monotodo.ui.home.HomeScreen
+import com.example.monotodo.ui.task.TaskCompletedDestination
+import com.example.monotodo.ui.task.TaskCompletedScreen
+import com.example.monotodo.ui.task.TaskEntryDestination
+import com.example.monotodo.ui.task.TaskEntryScreen
+
+@Composable
+fun MonoTodoNavHost(
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+) {
+    NavHost(
+        navController = navController,
+        startDestination = HomeDestination.route,
+        modifier = modifier
+    ) {
+        composable(route = HomeDestination.route) {
+            HomeScreen(
+                navigateToTaskEntry = { navController.navigate(TaskEntryDestination.route) },
+                navigateToTaskCompleted = { navController.navigate(TaskCompletedDestination.route) }
+            )
+        }
+        composable(route = TaskCompletedDestination.route) {
+            TaskCompletedScreen(
+                navigateToTaskEntry = { navController.navigate(TaskEntryDestination.route) },
+                onNavigateUp = { navController.popBackStack() }
+            )
+        }
+        composable(route = TaskEntryDestination.route) {
+            TaskEntryScreen(
+                navigateBack = { navController.popBackStack(HomeDestination.route, inclusive = false) },
+                onNavigateUp = { navController.popBackStack() }
+            )
+
+        }
+    }
+}

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/navigation/NavigationDestination.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/navigation/NavigationDestination.kt
@@ -1,0 +1,6 @@
+package com.example.monotodo.ui.navigation
+
+interface NavigationDestination {
+    val route: String
+    val titleRes: Int
+}

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedScreen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedScreen.kt
@@ -26,7 +26,13 @@ import com.example.monotodo.MonoTodoTopAppBar
 import com.example.monotodo.R
 import com.example.monotodo.data.Task
 import com.example.monotodo.ui.home.TaskList
+import com.example.monotodo.ui.navigation.NavigationDestination
 import com.example.monotodo.ui.theme.MonoTodoTheme
+
+object TaskCompletedDestination : NavigationDestination {
+    override val route = "task_completed"
+    override val titleRes = R.string.task_completed_title
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -42,7 +48,7 @@ fun TaskCompletedScreen(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             MonoTodoTopAppBar(
-                title = stringResource(R.string.task_completed_title),
+                title = stringResource(TaskCompletedDestination.titleRes),
                 canNavigateBack = canNavigateBack,
                 navigateUp = onNavigateUp,
                 scrollBehavior = scrollBehavior,

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskEntryScreen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskEntryScreen.kt
@@ -18,7 +18,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.monotodo.MonoTodoTopAppBar
 import com.example.monotodo.R
+import com.example.monotodo.ui.navigation.NavigationDestination
 import com.example.monotodo.ui.theme.MonoTodoTheme
+
+object TaskEntryDestination : NavigationDestination {
+    override val route = "task_entry"
+    override val titleRes = R.string.task_entry_title
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -26,12 +32,12 @@ fun TaskEntryScreen(
     navigateBack: () -> Unit,
     onNavigateUp: () -> Unit,
     canNavigateBack: Boolean = true,
-    viewModel: TaskEntryViewModel
+    viewModel: TaskEntryViewModel = TaskEntryViewModel()
 ) {
     Scaffold(
         topBar = {
             MonoTodoTopAppBar(
-                title = stringResource(R.string.task_entry_title),
+                title = stringResource(TaskEntryDestination.titleRes),
                 canNavigateBack = canNavigateBack,
                 navigateUp = onNavigateUp
             )
@@ -47,7 +53,7 @@ fun TaskEntryScreen(
                 taskUiState = viewModel.taskUiState,
                 modifier = Modifier.fillMaxWidth(),
                 onTaskValueChange = viewModel::updateUiState,
-                onSaveClick = {}
+                onSaveClick = navigateBack
             )
         }
     }


### PR DESCRIPTION
## 概要

Navigation Componentによる画面遷移の実装

## 変更点

- Navigation Componentによる仕様書に沿った画面遷移の実装
- 「Save」ボタンでタスク一覧画面（ホーム画面）への遷移実装
- 不要なコードの削除（MainActivity.kt）