### PR TITLE
Retrofitを利用し名言教えるよAPIから取得した名言表示機能

### DIFF
--- a/MonoTodo/app/src/main/AndroidManifest.xml
+++ b/MonoTodo/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".MonoTodoApplication"
         android:allowBackup="true"

--- a/MonoTodo/app/src/main/java/com/example/monotodo/data/AppContainer.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/data/AppContainer.kt
@@ -1,13 +1,36 @@
 package com.example.monotodo.data
 
 import android.content.Context
+import com.example.monotodo.network.MeigenApiService
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
 
 interface AppContainer {
     val tasksRepository: TasksRepository
+    val meigenRepository: MeigenRepository
 }
 
 class DefaultAppContainer(private val context: Context) : AppContainer {
     override val tasksRepository: TasksRepository by lazy {
         DefaultTasksRepository(MonoTodoDatabase.getDatabase(context).taskDao())
+    }
+
+    companion object {
+        private const val BASE_URL = "https://meigen.doodlenote.net/api/"
+    }
+
+    private val retrofit: Retrofit = Retrofit.Builder()
+        .addConverterFactory(GsonConverterFactory.create())
+        .baseUrl(BASE_URL)
+        .build()
+
+    private val retrofitService: MeigenApiService by lazy {
+        retrofit.create(MeigenApiService::class.java)
+    }
+
+    override val meigenRepository: MeigenRepository by lazy {
+        DefaultMeigenRepository(
+            meigenApiService = retrofitService,
+            context = context)
     }
 }

--- a/MonoTodo/app/src/main/java/com/example/monotodo/data/DefaultMeigenRepository.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/data/DefaultMeigenRepository.kt
@@ -1,0 +1,31 @@
+package com.example.monotodo.data
+
+import android.content.Context
+import com.example.monotodo.network.Meigen
+import com.example.monotodo.network.MeigenApiService
+
+class DefaultMeigenRepository(
+    private val meigenApiService: MeigenApiService,
+    private val context: Context
+) : MeigenRepository {
+
+    override suspend fun getRandomMeigenFromApiOrLocal(): List<Meigen> {
+        return try {
+            val meigenList = meigenApiService.getRandomMeigen()
+
+            if (meigenList.isNotEmpty()) {
+                meigenList
+            } else {
+                fallbackToLocal()
+            }
+        } catch (e: Exception) {
+            fallbackToLocal()
+        }
+    }
+
+    private fun fallbackToLocal(): List<Meigen> {
+        val localMeigens = LocalMeigenData.getFallbackMeigens(context)
+        val randomMeigen = localMeigens.random()
+        return listOf(randomMeigen)
+    }
+}

--- a/MonoTodo/app/src/main/java/com/example/monotodo/data/DefaultMeigenRepository.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/data/DefaultMeigenRepository.kt
@@ -13,9 +13,7 @@ class DefaultMeigenRepository(
         return try {
             val meigenList = meigenApiService.getRandomMeigen()
 
-            if (meigenList.isNotEmpty()) {
-                meigenList
-            } else {
+            meigenList.ifEmpty {
                 fallbackToLocal()
             }
         } catch (e: Exception) {

--- a/MonoTodo/app/src/main/java/com/example/monotodo/data/LocalMeigenData.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/data/LocalMeigenData.kt
@@ -1,0 +1,46 @@
+package com.example.monotodo.data
+
+import android.content.Context
+import com.example.monotodo.network.Meigen
+import com.example.monotodo.R
+
+// フォールバック用にローカル名言リストをまとめたobject
+object LocalMeigenData {
+    fun getFallbackMeigens(context: Context): List<Meigen> {
+        val resources = context.resources
+        return listOf(
+            Meigen(
+                meigen = resources.getString(R.string.fallback_meigen_1_text),
+                auther = resources.getString(R.string.fallback_meigen_1_auther)
+            ),
+            Meigen(
+                meigen = resources.getString(R.string.fallback_meigen_2_text),
+                auther = resources.getString(R.string.fallback_meigen_2_auther)
+            ),
+            Meigen(
+                meigen = resources.getString(R.string.fallback_meigen_3_text),
+                auther = resources.getString(R.string.fallback_meigen_3_auther)
+            ),
+            Meigen(
+                meigen = resources.getString(R.string.fallback_meigen_4_text),
+                auther = resources.getString(R.string.fallback_meigen_4_auther)
+            ),
+            Meigen(
+                meigen = resources.getString(R.string.fallback_meigen_5_text),
+                auther = resources.getString(R.string.fallback_meigen_5_auther)
+            ),
+            Meigen(
+                meigen = resources.getString(R.string.fallback_meigen_6_text),
+                auther = resources.getString(R.string.fallback_meigen_6_auther)
+            ),
+            Meigen(
+                meigen = resources.getString(R.string.fallback_meigen_7_text),
+                auther = resources.getString(R.string.fallback_meigen_7_auther)
+            ),
+            Meigen(
+                meigen = resources.getString(R.string.fallback_meigen_8_text),
+                auther = resources.getString(R.string.fallback_meigen_8_auther)
+            )
+        )
+    }
+}

--- a/MonoTodo/app/src/main/java/com/example/monotodo/data/MeigenRepository.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/data/MeigenRepository.kt
@@ -1,0 +1,7 @@
+package com.example.monotodo.data
+
+import com.example.monotodo.network.Meigen
+
+interface MeigenRepository {
+    suspend fun getRandomMeigenFromApiOrLocal(): List<Meigen>
+}

--- a/MonoTodo/app/src/main/java/com/example/monotodo/network/Meigen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/network/Meigen.kt
@@ -1,0 +1,7 @@
+package com.example.monotodo.network
+
+// 名言教えるよAPIのJSONキー"meigen"と"auther"に準拠したdata class
+data class Meigen(
+    val meigen: String,
+    val auther: String
+)

--- a/MonoTodo/app/src/main/java/com/example/monotodo/network/MeigenApiService.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/network/MeigenApiService.kt
@@ -1,0 +1,8 @@
+package com.example.monotodo.network
+
+import retrofit2.http.GET
+
+interface MeigenApiService {
+    @GET("json.php")
+    suspend fun getRandomMeigen(): List<Meigen>
+}

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/AppViewModelProvider.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/AppViewModelProvider.kt
@@ -12,11 +12,17 @@ import com.example.monotodo.ui.task.TaskEntryViewModel
 object AppViewModelProvider {
     val Factory = viewModelFactory {
         initializer {
-            HomeViewModel(monoTodoApplication().container.tasksRepository)
+            HomeViewModel(
+                monoTodoApplication().container.tasksRepository,
+                monoTodoApplication().container.meigenRepository
+            )
         }
 
         initializer {
-            TaskCompletedViewModel(monoTodoApplication().container.tasksRepository)
+            TaskCompletedViewModel(
+                monoTodoApplication().container.tasksRepository,
+                monoTodoApplication().container.meigenRepository
+            )
         }
 
         initializer {

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeScreen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -57,6 +58,7 @@ fun HomeScreen(
 ) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val homeUiState by viewModel.homeUiState.collectAsState()
+    val homeMeigenUiState by viewModel.homeMeigenUiState.collectAsState()
 
     Scaffold(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -81,17 +83,77 @@ fun HomeScreen(
             }
         },
     ) { innerPadding ->
-        HomeBody(
-            taskList = homeUiState.itemList,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = innerPadding,
-            onDelete = { task ->
-                viewModel.deleteTask(task)
-            },
-            onToggleCompletion = { task, isCompleted ->
-                viewModel.toggleTaskCompletion(task, isCompleted)
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            HomeMeigenSection(
+                meigenUiState = homeMeigenUiState,
+                modifier = Modifier.weight(1f)
+            )
+            HomeBody(
+                taskList = homeUiState.itemList,
+                modifier = Modifier.weight(1f),
+                contentPadding = PaddingValues(0.dp),
+                onDelete = { task ->
+                    viewModel.deleteTask(task)
+                },
+                onToggleCompletion = { task, isCompleted ->
+                    viewModel.toggleTaskCompletion(task, isCompleted)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun HomeMeigenSection(
+    meigenUiState: HomeMeigenUiState,
+    modifier: Modifier = Modifier
+) {
+    when (meigenUiState) {
+        HomeMeigenUiState.Loading -> {
+            Text(
+                text = stringResource(R.string.loading),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(dimensionResource(R.dimen.padding_small))
+            )
+        }
+        HomeMeigenUiState.Error -> {
+            Text(
+                text = stringResource(R.string.failed_to_retrieve_quote),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(dimensionResource(R.dimen.padding_small))
+            )
+        }
+        is HomeMeigenUiState.Success -> {
+            val meigen = meigenUiState.meigen
+            Column(
+                modifier = Modifier
+                    .padding(dimensionResource(R.dimen.padding_small))
+                    .fillMaxWidth()
+            ) {
+                Text(
+                    text = meigen.meigen,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(dimensionResource(R.dimen.padding_small))
+                )
+                Text(
+                    text = meigen.auther,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier
+                        .padding(dimensionResource(R.dimen.padding_small))
+                        .align(Alignment.End)
+                )
             }
-        )
+        }
     }
 }
 

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeScreen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeScreen.kt
@@ -118,7 +118,7 @@ fun HomeMeigenSection(
                 text = stringResource(R.string.loading),
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
+                modifier = modifier
                     .fillMaxWidth()
                     .padding(dimensionResource(R.dimen.padding_small))
             )
@@ -128,7 +128,7 @@ fun HomeMeigenSection(
                 text = stringResource(R.string.failed_to_retrieve_quote),
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
+                modifier = modifier
                     .fillMaxWidth()
                     .padding(dimensionResource(R.dimen.padding_small))
             )

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeViewModel.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeViewModel.kt
@@ -2,15 +2,23 @@ package com.example.monotodo.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.monotodo.data.MeigenRepository
 import com.example.monotodo.data.Task
 import com.example.monotodo.data.TasksRepository
+import com.example.monotodo.network.Meigen
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-class HomeViewModel(private val tasksRepository: TasksRepository) : ViewModel() {
+class HomeViewModel(
+    private val tasksRepository: TasksRepository,
+    private val meigenRepository: MeigenRepository
+) : ViewModel() {
+
     companion object {
         private const val TIMEOUT_MILLIS = 5_000L
     }
@@ -22,6 +30,13 @@ class HomeViewModel(private val tasksRepository: TasksRepository) : ViewModel() 
             started = SharingStarted.WhileSubscribed(TIMEOUT_MILLIS),
             initialValue = HomeUiState()
         )
+
+    private val _homeMeigenUiState = MutableStateFlow<HomeMeigenUiState>(HomeMeigenUiState.Loading)
+    val homeMeigenUiState: StateFlow<HomeMeigenUiState> = _homeMeigenUiState.asStateFlow()
+
+    init {
+        fetchRandomMeigen()
+    }
 
     fun deleteTask(task: Task) {
         viewModelScope.launch {
@@ -35,8 +50,27 @@ class HomeViewModel(private val tasksRepository: TasksRepository) : ViewModel() 
             tasksRepository.updateTask(updatedTask)
         }
     }
+
+    private fun fetchRandomMeigen() {
+        _homeMeigenUiState.value = HomeMeigenUiState.Loading
+        viewModelScope.launch {
+            val meigens: List<Meigen> = meigenRepository.getRandomMeigenFromApiOrLocal()
+            val meigen: Meigen? = meigens.firstOrNull()
+            if (meigen != null) {
+                _homeMeigenUiState.value = HomeMeigenUiState.Success(meigen)
+            } else {
+                _homeMeigenUiState.value = HomeMeigenUiState.Error
+            }
+        }
+    }
 }
 
 data class HomeUiState(
     val itemList: List<Task> = listOf()
 )
+
+sealed interface HomeMeigenUiState {
+    object Loading : HomeMeigenUiState
+    data class Success(val meigen: Meigen) : HomeMeigenUiState
+    object Error : HomeMeigenUiState
+}

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedScreen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedScreen.kt
@@ -3,6 +3,7 @@ package com.example.monotodo.ui.task
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -48,6 +49,7 @@ fun TaskCompletedScreen(
 ) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val taskCompletedUiState = viewModel.taskCompletedUiState.collectAsState()
+    val taskCompletedMeigenUiState = viewModel.taskCompletedMeigenUiState.collectAsState()
 
     Scaffold(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -72,17 +74,77 @@ fun TaskCompletedScreen(
             }
         },
     ) { innerPadding ->
-        TaskCompletedBody(
-            taskList = taskCompletedUiState.value.taskList,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = innerPadding,
-            onDelete = { task ->
-                viewModel.deleteTask(task)
-            },
-            onToggleCompletion = { task, isCompleted ->
-                viewModel.toggleTaskCompletion(task, isCompleted)
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+        ) {
+            TaskCompletedMeigenSection(
+                meigenUiState = taskCompletedMeigenUiState.value,
+                modifier = Modifier.weight(1f)
+            )
+            TaskCompletedBody(
+                taskList = taskCompletedUiState.value.taskList,
+                modifier = Modifier.weight(1f),
+                contentPadding = PaddingValues(0.dp),
+                onDelete = { task ->
+                    viewModel.deleteTask(task)
+                },
+                onToggleCompletion = { task, isCompleted ->
+                    viewModel.toggleTaskCompletion(task, isCompleted)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun TaskCompletedMeigenSection(
+    meigenUiState: TaskCompletedMeigenUiState,
+    modifier: Modifier = Modifier
+) {
+    when (meigenUiState) {
+        TaskCompletedMeigenUiState.Loading -> {
+            Text(
+                text = stringResource(R.string.loading),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(dimensionResource(R.dimen.padding_small))
+            )
+        }
+        TaskCompletedMeigenUiState.Error -> {
+            Text(
+                text = stringResource(R.string.failed_to_retrieve_quote),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(dimensionResource(R.dimen.padding_small))
+            )
+        }
+        is TaskCompletedMeigenUiState.Success -> {
+            val meigen = meigenUiState.meigen
+            Column(
+                modifier = Modifier
+                    .padding(dimensionResource(R.dimen.padding_small))
+                    .fillMaxWidth()
+            ) {
+                Text(
+                    text = meigen.meigen,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(dimensionResource(R.dimen.padding_small))
+                )
+                Text(
+                    text = meigen.auther,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier
+                        .padding(dimensionResource(R.dimen.padding_small))
+                        .align(Alignment.End)
+                )
             }
-        )
+        }
     }
 }
 

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedScreen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedScreen.kt
@@ -109,7 +109,7 @@ fun TaskCompletedMeigenSection(
                 text = stringResource(R.string.loading),
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
+                modifier = modifier
                     .fillMaxWidth()
                     .padding(dimensionResource(R.dimen.padding_small))
             )
@@ -119,7 +119,7 @@ fun TaskCompletedMeigenSection(
                 text = stringResource(R.string.failed_to_retrieve_quote),
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
+                modifier = modifier
                     .fillMaxWidth()
                     .padding(dimensionResource(R.dimen.padding_small))
             )

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedViewModel.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedViewModel.kt
@@ -2,15 +2,23 @@ package com.example.monotodo.ui.task
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.monotodo.data.MeigenRepository
 import com.example.monotodo.data.Task
 import com.example.monotodo.data.TasksRepository
+import com.example.monotodo.network.Meigen
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-class TaskCompletedViewModel(private val tasksRepository: TasksRepository) : ViewModel() {
+class TaskCompletedViewModel(
+    private val tasksRepository: TasksRepository,
+    private val meigenRepository: MeigenRepository
+) : ViewModel() {
+
     companion object {
         private const val TIMEOUT_MILLIS = 5_000L
     }
@@ -22,6 +30,13 @@ class TaskCompletedViewModel(private val tasksRepository: TasksRepository) : Vie
             started = SharingStarted.WhileSubscribed(TIMEOUT_MILLIS),
             initialValue = TaskCompletedUiState()
         )
+
+    private val _taskCompletedMeigenUiState = MutableStateFlow<TaskCompletedMeigenUiState>(TaskCompletedMeigenUiState.Loading)
+    val taskCompletedMeigenUiState: StateFlow<TaskCompletedMeigenUiState> = _taskCompletedMeigenUiState.asStateFlow()
+
+    init {
+        fetchRandomMeigen()
+    }
 
     fun deleteTask(task: Task) {
         viewModelScope.launch {
@@ -35,8 +50,27 @@ class TaskCompletedViewModel(private val tasksRepository: TasksRepository) : Vie
             tasksRepository.updateTask(updatedTask)
         }
     }
+
+    private fun fetchRandomMeigen() {
+        _taskCompletedMeigenUiState.value = TaskCompletedMeigenUiState.Loading
+        viewModelScope.launch {
+            val meigens: List<Meigen> = meigenRepository.getRandomMeigenFromApiOrLocal()
+            val meigen: Meigen? = meigens.firstOrNull()
+            if (meigen != null) {
+                _taskCompletedMeigenUiState.value = TaskCompletedMeigenUiState.Success(meigen)
+            } else {
+                _taskCompletedMeigenUiState.value = TaskCompletedMeigenUiState.Error
+            }
+        }
+    }
 }
 
 data class TaskCompletedUiState(
     val taskList: List<Task> = listOf()
 )
+
+sealed interface TaskCompletedMeigenUiState {
+    object Loading : TaskCompletedMeigenUiState
+    data class Success(val meigen: Meigen) : TaskCompletedMeigenUiState
+    object Error : TaskCompletedMeigenUiState
+}

--- a/MonoTodo/app/src/main/res/values/strings.xml
+++ b/MonoTodo/app/src/main/res/values/strings.xml
@@ -10,4 +10,32 @@
     <string name="task_title_req">Task title*</string>
     <string name="required_fields">*required fields</string>
     <string name="save_action">Save</string>
+    <string name="loading">Loading...</string>
+    <string name="failed_to_retrieve_quote">Failed to retrieve quote.</string>
+
+    <!-- 名言の取得に失敗した場合に表示するフォールバック用の名言と著者 -->
+    <string name="fallback_meigen_1_text">All our dreams can come true, if we have the courage to pursue them.</string>
+    <string name="fallback_meigen_1_auther">Walt Disney</string>
+
+    <string name="fallback_meigen_2_text">All you need in this life is ignorance and confidence, and then success is sure.</string>
+    <string name="fallback_meigen_2_auther">Mark Twain</string>
+
+    <string name="fallback_meigen_3_text">Do what you feel in your heart to be right – for you’ll be criticized anyway.</string>
+    <string name="fallback_meigen_3_auther">Eleanor Roosevelt</string>
+
+    <string name="fallback_meigen_4_text">Indecision is often worse than wrong action.</string>
+    <string name="fallback_meigen_4_auther">Henry Ford</string>
+
+    <string name="fallback_meigen_5_text">Life is like riding a bicycle. To keep your balance you must keep moving.</string>
+    <string name="fallback_meigen_5_auther">Albert Einstein</string>
+
+    <string name="fallback_meigen_6_text">Success is the ability to go from failure to failure without losing your enthusiasm.</string>
+    <string name="fallback_meigen_6_auther">Winston Churchill</string>
+
+    <string name="fallback_meigen_7_text">Things may come to those who wait, but only the things left by those who hustle.</string>
+    <string name="fallback_meigen_7_auther">Abraham Lincoln</string>
+
+    <string name="fallback_meigen_8_text">You’ll never find a rainbow if you’re looking down.</string>
+    <string name="fallback_meigen_8_auther">Charlie Chaplin</string>
+
 </resources>


### PR DESCRIPTION
## 概要

Retrofitを利用し名言教えるよAPIから取得した名言表示機能

## 変更点

- データソースであるMeigenApiService.ktとMeigen.ktの実装
- フォールバック用にローカル名言リストをまとめたLocalMeigenData.ktの実装
- 依存性注入(DI)のためのDIコンテナ(AppContainer.kt)の変更
- 依存性注入(DI)のためのリポジトリ(MeigenRepository)の実装
- ViewModelを介してタスク一覧画面と完了タスク一覧画面に名言を表示

## 備考

通信エラーなどでAPIから名言の取得に失敗した際にはLocalMeigenData.ktからランダムに名言を取得し表示する機能を追加