### PR TITLE
アプリが英語と日本語の二言語に対応できる機能の実装

### DIFF
--- a/MonoTodo/app/src/main/java/com/example/monotodo/data/DefaultMeigenRepository.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/data/DefaultMeigenRepository.kt
@@ -10,6 +10,10 @@ class DefaultMeigenRepository(
 ) : MeigenRepository {
 
     override suspend fun getRandomMeigenFromApiOrLocal(): List<Meigen> {
+        if (!isJapanese(context)) {
+            return fallbackToLocal()
+        }
+
         return try {
             val meigenList = meigenApiService.getRandomMeigen()
 
@@ -25,5 +29,10 @@ class DefaultMeigenRepository(
         val localMeigens = LocalMeigenData.getFallbackMeigens(context)
         val randomMeigen = localMeigens.random()
         return listOf(randomMeigen)
+    }
+
+    private fun isJapanese(context: Context): Boolean {
+        val locale = context.resources.configuration.locales[0]
+        return locale.language == "ja"
     }
 }

--- a/MonoTodo/app/src/main/res/values-ja/strings.xml
+++ b/MonoTodo/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">MonoTodo</string>
+    <string name="delete">削除</string>
+    <string name="no_task_description">タスクを登録しよう！</string>
+    <string name="back_button">Back</string>
+    <string name="navigate_to_task_completed_button">完了したタスク一覧を表示</string>
+    <string name="task_entry_title">Add Task</string>
+    <string name="no_completed_task_description">タスクを完了させよう！</string>
+    <string name="task_completed_title">Completed Tasks</string>
+    <string name="task_title_req">タスクを入力*</string>
+    <string name="required_fields">*必須項目</string>
+    <string name="save_action">Save</string>
+    <string name="loading">Loading...</string>
+    <string name="failed_to_retrieve_quote">名言の取得に失敗しました</string>
+
+    <!-- 名言の取得に失敗した場合に表示するフォールバック用の名言と著者 -->
+    <string name="fallback_meigen_1_text">夢は追い続ける勇気があれば、どんな夢も叶えられる。</string>
+    <string name="fallback_meigen_1_auther">ウォルト・ディズニー</string>
+
+    <string name="fallback_meigen_2_text">あなたの人生で必要なことは「無知」と「自信」。</string>
+    <string name="fallback_meigen_2_auther">マーク・トウェイン</string>
+
+    <string name="fallback_meigen_3_text">あなたが正しいと感じることをしなさい。いずれにしろ批判されるのだから。</string>
+    <string name="fallback_meigen_3_auther">エレノア・ルーズベルト</string>
+
+    <string name="fallback_meigen_4_text">決断しないことは、時として間違った行動よりたちが悪い。</string>
+    <string name="fallback_meigen_4_auther">ヘンリー・フォード</string>
+
+    <string name="fallback_meigen_5_text">Life is like riding a bicycle. To keep your balance you must keep moving.</string>
+    <string name="fallback_meigen_5_auther">Albert Einstein</string>
+
+    <string name="fallback_meigen_6_text">成功とは、失敗を重ねても、やる気を失わないでいられる才能である。</string>
+    <string name="fallback_meigen_6_auther">ウィンストン・チャーチル</string>
+
+    <string name="fallback_meigen_7_text">待っていれば何かが起こるかもしれないが、それは頑張った人の残り物だけである。</string>
+    <string name="fallback_meigen_7_auther">エイブラハム・リンカーン</string>
+
+    <string name="fallback_meigen_8_text">下を向いていたら、虹を見つけることは出来ないよ。</string>
+    <string name="fallback_meigen_8_auther">チャーリー・チャップリン</string>
+</resources>

--- a/MonoTodo/app/src/main/res/values/strings.xml
+++ b/MonoTodo/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">MonoTodo</string>
     <string name="delete">Delete</string>
@@ -37,5 +38,4 @@
 
     <string name="fallback_meigen_8_text">You’ll never find a rainbow if you’re looking down.</string>
     <string name="fallback_meigen_8_auther">Charlie Chaplin</string>
-
 </resources>


### PR DESCRIPTION
## 概要

- アプリが英語と日本語の二言語に対応できる機能の実装
- 「名言教えるよAPI」から取得する文字列が日本語のため、言語設定が日本語以外なら、全てローカルに定義した名言リストからのみ名言を取得するという仕様への変更

## 変更点

- 一貫性を保つためres/values/strings.xmlにエンコーディング指定
- 日本語対応用のstringリソースファイルの作成
- 言語設定が日本語以外なら、ローカルに定義した名言リストからのみ名言を取得するという仕様への変更