### PR TITLE
タスク一覧画面と完了タスク一覧画面にて同じ名言が表示される様に修正

### DIFF
--- a/MonoTodo/.idea/deploymentTargetSelector.xml
+++ b/MonoTodo/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-01-03T09:35:53.378732Z">
+        <DropdownSelection timestamp="2025-01-04T11:48:21.852012Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/hideichi/.android/avd/Medium_Phone_API_35.avd" />
+              <DeviceId pluginId="Default" identifier="serial=emulator-5554;connection=f7fe510a" />
             </handle>
           </Target>
         </DropdownSelection>


### PR DESCRIPTION
## 概要

タスク一覧画面と完了タスク一覧画面にて同じ名言が表示される様に修正

## 変更点

- 一度取得した名言リストをキャッシュし保持する機能
- キャッシュ済みならば再取得せずにそのまま返す仕様に変更

close #13 