### PR TITLE
名言セクションの表示領域を固定して、状態遷移時のレイアウトシフトを防止する

### DIFF
--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeScreen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeScreen.kt
@@ -88,7 +88,7 @@ fun HomeScreen(
         ) {
             HomeMeigenSection(
                 meigenUiState = homeMeigenUiState,
-                modifier = Modifier.weight(1f)
+                modifier = modifier
             )
             HomeBody(
                 taskList = homeUiState.itemList,
@@ -118,7 +118,7 @@ fun HomeMeigenSection(
                 style = MaterialTheme.typography.bodyLarge,
                 modifier = modifier
                     .fillMaxWidth()
-                    .padding(dimensionResource(R.dimen.padding_small))
+                    .padding(dimensionResource(R.dimen.padding_extra_large))
             )
         }
         HomeMeigenUiState.Error -> {
@@ -128,15 +128,15 @@ fun HomeMeigenSection(
                 style = MaterialTheme.typography.bodyLarge,
                 modifier = modifier
                     .fillMaxWidth()
-                    .padding(dimensionResource(R.dimen.padding_small))
+                    .padding(dimensionResource(R.dimen.padding_extra_large))
             )
         }
         is HomeMeigenUiState.Success -> {
             val meigen = meigenUiState.meigen
             Column(
-                modifier = Modifier
-                    .padding(dimensionResource(R.dimen.padding_small))
+                modifier = modifier
                     .fillMaxWidth()
+                    .padding(dimensionResource(R.dimen.padding_small))
             ) {
                 Text(
                     text = meigen.meigen,

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedScreen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedScreen.kt
@@ -81,7 +81,7 @@ fun TaskCompletedScreen(
         ) {
             TaskCompletedMeigenSection(
                 meigenUiState = taskCompletedMeigenUiState.value,
-                modifier = Modifier.weight(1f)
+                modifier = modifier
             )
             TaskCompletedBody(
                 taskList = taskCompletedUiState.value.taskList,
@@ -111,7 +111,7 @@ fun TaskCompletedMeigenSection(
                 style = MaterialTheme.typography.bodyLarge,
                 modifier = modifier
                     .fillMaxWidth()
-                    .padding(dimensionResource(R.dimen.padding_small))
+                    .padding(dimensionResource(R.dimen.padding_extra_large))
             )
         }
         TaskCompletedMeigenUiState.Error -> {
@@ -121,15 +121,15 @@ fun TaskCompletedMeigenSection(
                 style = MaterialTheme.typography.bodyLarge,
                 modifier = modifier
                     .fillMaxWidth()
-                    .padding(dimensionResource(R.dimen.padding_small))
+                    .padding(dimensionResource(R.dimen.padding_extra_large))
             )
         }
         is TaskCompletedMeigenUiState.Success -> {
             val meigen = meigenUiState.meigen
             Column(
-                modifier = Modifier
-                    .padding(dimensionResource(R.dimen.padding_small))
+                modifier = modifier
                     .fillMaxWidth()
+                    .padding(dimensionResource(R.dimen.padding_small))
             ) {
                 Text(
                     text = meigen.meigen,


### PR DESCRIPTION
## 概要

名言セクションの表示領域を固定して、状態遷移時のレイアウトシフトをある程度防止できる様に修正

## 変更点

- ローディング、エラー状態でもSuccess状態と同じmodifierを適用し、表示領域をできるだけ一貫させる。

## 備考

名言セクションの表示領域は取得する名言の文字数によって変動する仕様のため、表示領域を完全に固定しない予定。

close #15 