### PR TITLE
名言セクションの表示のON/OFFをPreferences DataStoreを用いて実装

### DIFF
--- a/MonoTodo/.idea/AndroidProjectSystem.xml
+++ b/MonoTodo/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/MonoTodo/.idea/compiler.xml
+++ b/MonoTodo/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/MonoTodo/.idea/gradle.xml
+++ b/MonoTodo/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
@@ -12,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/MonoTodo/.idea/misc.xml
+++ b/MonoTodo/.idea/misc.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/MonoTodo/.idea/runConfigurations.xml
+++ b/MonoTodo/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/MonoTodo/app/build.gradle.kts
+++ b/MonoTodo/app/build.gradle.kts
@@ -80,6 +80,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.savedstate)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    // Preferences DataStore
+    implementation(libs.androidx.datastore.preferences)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/MonoTodo/app/src/main/java/com/example/monotodo/MonoTodoApp.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/MonoTodoApp.kt
@@ -2,6 +2,7 @@
 
 package com.example.monotodo
 
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Done
@@ -36,10 +37,16 @@ fun MonoTodoTopAppBar(
     modifier: Modifier = Modifier,
     scrollBehavior: TopAppBarScrollBehavior? = null,
     navigateUp: () -> Unit = {},
-    navigateToTaskCompleted: () -> Unit = {}
+    navigateToTaskCompleted: () -> Unit = {},
+    onTitleClick: () -> Unit = {}
 ) {
     CenterAlignedTopAppBar(
-        title = { Text(title) },
+        title = {
+            Text(
+                text = title,
+                modifier = Modifier.clickable { onTitleClick() }
+            )
+        },
         modifier = modifier,
         scrollBehavior = scrollBehavior,
         navigationIcon = {

--- a/MonoTodo/app/src/main/java/com/example/monotodo/data/AppContainer.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/data/AppContainer.kt
@@ -1,6 +1,9 @@
 package com.example.monotodo.data
 
 import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
 import com.example.monotodo.network.MeigenApiService
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -8,6 +11,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 interface AppContainer {
     val tasksRepository: TasksRepository
     val meigenRepository: MeigenRepository
+    val userPreferencesRepository: UserPreferencesRepository
 }
 
 class DefaultAppContainer(private val context: Context) : AppContainer {
@@ -17,6 +21,7 @@ class DefaultAppContainer(private val context: Context) : AppContainer {
 
     companion object {
         private const val BASE_URL = "https://meigen.doodlenote.net/api/"
+        private const val PREFERENCES_NAME = "user_preferences"
     }
 
     private val retrofit: Retrofit = Retrofit.Builder()
@@ -33,5 +38,11 @@ class DefaultAppContainer(private val context: Context) : AppContainer {
             meigenApiService = retrofitService,
             context = context
         )
+    }
+
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = PREFERENCES_NAME)
+
+    override val userPreferencesRepository: UserPreferencesRepository by lazy {
+        DefaultUserPreferencesRepository(context.dataStore)
     }
 }

--- a/MonoTodo/app/src/main/java/com/example/monotodo/data/DefaultUserPreferencesRepository.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/data/DefaultUserPreferencesRepository.kt
@@ -1,0 +1,41 @@
+package com.example.monotodo.data
+
+import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+
+class DefaultUserPreferencesRepository(
+    private val dataStore: DataStore<Preferences>
+) : UserPreferencesRepository {
+
+    private companion object {
+        val IS_MEIGEN_DISPLAY_ENABLED = booleanPreferencesKey("is_meigen_display_enabled")
+        const val TAG = "UserPreferencesRepo"
+    }
+
+    override val isMeigenDisplayEnabled: Flow<Boolean> = dataStore.data
+        .catch {
+            if (it is IOException) {
+                Log.e(TAG, "Error reading preferences.", it)
+                emit(emptyPreferences())
+            } else {
+                throw it
+            }
+        }
+        .map { preferences ->
+            preferences[IS_MEIGEN_DISPLAY_ENABLED] ?: true
+        }
+
+    override suspend fun setMeigenDisplayEnabled(isMeigenDisplayEnabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[IS_MEIGEN_DISPLAY_ENABLED] = isMeigenDisplayEnabled
+        }
+    }
+}

--- a/MonoTodo/app/src/main/java/com/example/monotodo/data/UserPreferencesRepository.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/data/UserPreferencesRepository.kt
@@ -1,0 +1,8 @@
+package com.example.monotodo.data
+
+import kotlinx.coroutines.flow.Flow
+
+interface UserPreferencesRepository {
+    val isMeigenDisplayEnabled: Flow<Boolean>
+    suspend fun setMeigenDisplayEnabled(isMeigenDisplayEnabled: Boolean)
+}

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/AppViewModelProvider.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/AppViewModelProvider.kt
@@ -14,14 +14,16 @@ object AppViewModelProvider {
         initializer {
             HomeViewModel(
                 monoTodoApplication().container.tasksRepository,
-                monoTodoApplication().container.meigenRepository
+                monoTodoApplication().container.meigenRepository,
+                monoTodoApplication().container.userPreferencesRepository
             )
         }
 
         initializer {
             TaskCompletedViewModel(
                 monoTodoApplication().container.tasksRepository,
-                monoTodoApplication().container.meigenRepository
+                monoTodoApplication().container.meigenRepository,
+                monoTodoApplication().container.userPreferencesRepository
             )
         }
 

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeScreen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/home/HomeScreen.kt
@@ -57,6 +57,7 @@ fun HomeScreen(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val homeUiState by viewModel.homeUiState.collectAsState()
     val homeMeigenUiState by viewModel.homeMeigenUiState.collectAsState()
+    val homePreferencesUiState by viewModel.homePreferencesUiState.collectAsState()
 
     Scaffold(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -65,7 +66,8 @@ fun HomeScreen(
                 title = stringResource(HomeDestination.titleRes),
                 canNavigateBack = false,
                 scrollBehavior = scrollBehavior,
-                navigateToTaskCompleted = navigateToTaskCompleted
+                navigateToTaskCompleted = navigateToTaskCompleted,
+                onTitleClick = { viewModel.toggleMeigenDisplayPreference(homePreferencesUiState.isMeigenDisplayEnabled) }
             )
         },
         floatingActionButton = {
@@ -86,10 +88,12 @@ fun HomeScreen(
                 .padding(innerPadding)
                 .fillMaxSize()
         ) {
-            HomeMeigenSection(
-                meigenUiState = homeMeigenUiState,
-                modifier = modifier
-            )
+            if (homePreferencesUiState.isMeigenDisplayEnabled) {
+                HomeMeigenSection(
+                    meigenUiState = homeMeigenUiState,
+                    modifier = modifier
+                )
+            }
             HomeBody(
                 taskList = homeUiState.itemList,
                 modifier = Modifier.weight(1f),

--- a/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedScreen.kt
+++ b/MonoTodo/app/src/main/java/com/example/monotodo/ui/task/TaskCompletedScreen.kt
@@ -50,6 +50,7 @@ fun TaskCompletedScreen(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val taskCompletedUiState = viewModel.taskCompletedUiState.collectAsState()
     val taskCompletedMeigenUiState = viewModel.taskCompletedMeigenUiState.collectAsState()
+    val taskCompletedPreferencesUiState = viewModel.taskCompletedPreferencesUiState.collectAsState()
 
     Scaffold(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -58,7 +59,8 @@ fun TaskCompletedScreen(
                 title = stringResource(TaskCompletedDestination.titleRes),
                 canNavigateBack = canNavigateBack,
                 navigateUp = onNavigateUp,
-                scrollBehavior = scrollBehavior
+                scrollBehavior = scrollBehavior,
+                onTitleClick = { viewModel.toggleMeigenDisplayPreference(taskCompletedPreferencesUiState.value.isMeigenDisplayEnabled) }
             )
         },
         floatingActionButton = {
@@ -79,10 +81,12 @@ fun TaskCompletedScreen(
                 .padding(innerPadding)
                 .fillMaxSize()
         ) {
-            TaskCompletedMeigenSection(
-                meigenUiState = taskCompletedMeigenUiState.value,
-                modifier = modifier
-            )
+            if (taskCompletedPreferencesUiState.value.isMeigenDisplayEnabled) {
+                TaskCompletedMeigenSection(
+                    meigenUiState = taskCompletedMeigenUiState.value,
+                    modifier = modifier
+                )
+            }
             TaskCompletedBody(
                 taskList = taskCompletedUiState.value.taskList,
                 modifier = Modifier.weight(1f),

--- a/MonoTodo/gradle/libs.versions.toml
+++ b/MonoTodo/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ lifecycleViewModelSavedState = "2.8.7"
 lifecycleViewModelCompose = "2.8.7"
 # Ktlint
 ktlint = "11.4.0"
+# datastorePreferences
+datastorePreferences = "1.1.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -58,6 +60,8 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewModelKtx" }
 androidx-lifecycle-viewmodel-savedstate = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-savedstate", version.ref = "lifecycleViewModelSavedState" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelCompose" }
+# datastorePreferences
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 概要

名言セクションの表示のON/OFFをPreferences DataStoreを用いて実装

## 変更点

- GradleにdatastorePreferencesの依存関係を追加
- UserPreferencesRepository.ktの実装
- DefaultUserPreferencesRepository.ktの実装
- 依存性注入(DI)のためのDIコンテナ(AppContainer.kt)の変更
- 依存性注入(DI)のためのリポジトリ(UserPreferencesRepository)の実装
- ViewModelを介してタスク一覧画面と完了タスク一覧画面で名言の表示のON/OFF実装

## 備考

SharedPreferencesよりPreferences DataStoreが現在推奨されているためそちらを選択